### PR TITLE
Deliver Dancer Via Apache/CGI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ courses.dist
 library-directory-tree.json
 library-subject-tree.json
 textbook-tree.json
-development.yml
 *~
 <<<<<<< HEAD
 /webwork3/public/js/bower_components/*

--- a/conf/webwork.apache2-config.dist
+++ b/conf/webwork.apache2-config.dist
@@ -146,7 +146,15 @@ if ($webwork_url eq "") {
 	$Location{$webwork_htdocs_url} = { SetHandler => "none" };
 }
 
+
+##########################################################################
+# WeBWork 3
 # This sets up webwork 3 to be served via dancer via cgi
+# If you want to serve webwork 3 directly through dancer comment
+# out the following block, and then uncomment the proxy pass lines below
+# You will need to start dancer manually, or set it up as service
+##########################################################################
+
 my $webwork3_htdocs_dir = $webwork_dir."/webwork3/public";
 # Set up /webwork3 to point to the dispatch cgi
 push @ScriptAlias, [ "/webwork3" => "$webwork3_htdocs_dir/dispatch.fcgi" ];
@@ -162,7 +170,9 @@ Directory{"$webwork3_htdocs_dir"} = {
 
 </Perl>
 
-
+# These lines are for service WeBWork 3 through dancer directly.  
+#ProxyPass /webwork3 http://localhost:3000
+#ProxyPassReverse /webwork3 http://localhost:3000
 
 ####################################################################
 # WebworkSOAP handlers (for integration with moodle)

--- a/conf/webwork.apache2-config.dist
+++ b/conf/webwork.apache2-config.dist
@@ -35,9 +35,7 @@
 # The "show source" button is most useful for webwork "courses" used to train new authors
 # It is not desirable to expose the code of regular homework questions to students
 
-ScriptAliasMatch /webwork2_course_files/([^/]*)/show-source.cgi/(.*) /opt/webwork/courses/$1/html/show-source.cgi/$2
-
-
+#ScriptAliasMatch /webwork2_course_files/([^/]*)/show-source.cgi/(.*) /opt/webwork/courses/$1/html/show-source.cgi/$2
 
 PerlModule mod_perl2
 
@@ -97,7 +95,6 @@ eval "use lib '$pg_dir/lib'"; die $@ if $@;
 
 require Apache::WeBWorK; # force compilation of pretty much everything
 
-
 # At this point, the following configuration variables should be present for use
 # in wiring WeBWorK into Apache:
 # 
@@ -149,16 +146,22 @@ if ($webwork_url eq "") {
 	$Location{$webwork_htdocs_url} = { SetHandler => "none" };
 }
 
+# This sets up webwork 3 to be served via dancer via cgi
+my $webwork3_htdocs_dir = $webwork_dir."/webwork3/public";
+# Set up /webwork3 to point to the dispatch cgi
+push @ScriptAlias, [ "/webwork3" => "$webwork3_htdocs_dir/dispatch.fcgi" ];
+
+# Allow cgi to run in the webwork3 dir
+Directory{"$webwork3_htdocs_dir"} = {
+    AllowOverride => "None",
+    Options => "+ExecCGI -MultiViews +SymLinksIfOwnerMatch",
+    Order => "allow,deny",
+    Allow => "from all",
+    AddHandler => "fastcgi-script .fcgi",
+};
+
 </Perl>
 
-####################################################################
-# The RESTful webservice is to be running on port 3000 and this allows 
-# proper connection to it. 
-####################################################################
-
-
-#ProxyPass /webwork3 http://localhost:3000
-#ProxyPassReverse /webwork3 http://localhost:3000
 
 
 ####################################################################

--- a/conf/webwork.apache2-config.dist
+++ b/conf/webwork.apache2-config.dist
@@ -157,7 +157,10 @@ if ($webwork_url eq "") {
 
 my $webwork3_htdocs_dir = $webwork_dir."/webwork3/public";
 # Set up /webwork3 to point to the dispatch cgi
-push @ScriptAlias, [ "/webwork3" => "$webwork3_htdocs_dir/dispatch.fcgi" ];
+push @Alias, [ "/webwork3/js" => "$webwork3_htdocs_dir/js"];
+push @Alias, [ "/webwork3/css" => "$webwork3_htdocs_dir/css"];
+push @Alias, [ "/webwork3/images" => "$webwork3_htdocs_dir/images"];
+push @PerlConfig, "ScriptAlias /webwork3 $webwork3_htdocs_dir/dispatch.fcgi";
 
 # Allow cgi to run in the webwork3 dir
 Directory{"$webwork3_htdocs_dir"} = {

--- a/conf/webwork.apache2.4-config.dist
+++ b/conf/webwork.apache2.4-config.dist
@@ -35,9 +35,7 @@
 # The "show source" button is most useful for webwork "courses" used to train new authors
 # It is not desirable to expose the code of regular homework questions to students
 
-ScriptAliasMatch /webwork2_course_files/([^/]*)/show-source.cgi/(.*) /opt/webwork/courses/$1/html/show-source.cgi/$2
-
-
+#ScriptAliasMatch /webwork2_course_files/([^/]*)/show-source.cgi/(.*) /opt/webwork/courses/$1/html/show-source.cgi/$2
 
 PerlModule mod_perl2
 
@@ -144,6 +142,20 @@ if ($webwork_url eq "") {
 	$Location{$webwork_courses_url} = { SetHandler => "none" };
 	$Location{$webwork_htdocs_url} = { SetHandler => "none" };
 }
+
+# This sets up webwork 3 to be served via dancer via cgi
+my $webwork3_htdocs_dir = $webwork_dir."/webwork3/public";
+# Set up /webwork3 to point to the dispatch cgi
+push @ScriptAlias, [ "/webwork3" => "$webwork3_htdocs_dir/dispatch.fcgi" ];
+
+# Allow cgi to run in the webwork3 dir
+Directory{"$webwork3_htdocs_dir"} = {
+    AllowOverride => "None",
+    Options => "+ExecCGI -MultiViews +SymLinksIfOwnerMatch",
+    Require => "all granted",    
+    AddHandler => "fastcgi-script .fcgi",
+};
+
 
 </Perl>
 

--- a/conf/webwork.apache2.4-config.dist
+++ b/conf/webwork.apache2.4-config.dist
@@ -143,7 +143,14 @@ if ($webwork_url eq "") {
 	$Location{$webwork_htdocs_url} = { SetHandler => "none" };
 }
 
+##########################################################################
+# WeBWork 3
 # This sets up webwork 3 to be served via dancer via cgi
+# If you want to serve webwork 3 directly through dancer comment
+# out the following block, and then uncomment the proxy pass lines below
+# You will need to start dancer manually, or set it up as service
+##########################################################################
+
 my $webwork3_htdocs_dir = $webwork_dir."/webwork3/public";
 # Set up /webwork3 to point to the dispatch cgi
 push @ScriptAlias, [ "/webwork3" => "$webwork3_htdocs_dir/dispatch.fcgi" ];
@@ -156,8 +163,11 @@ Directory{"$webwork3_htdocs_dir"} = {
     AddHandler => "fastcgi-script .fcgi",
 };
 
-
 </Perl>
+
+# These lines are for service WeBWork 3 through dancer directly.  
+#ProxyPass /webwork3 http://localhost:3000
+#ProxyPassReverse /webwork3 http://localhost:3000
 
 ####################################################################
 # WebworkSOAP handlers (for integration with moodle)

--- a/conf/webwork.apache2.4-config.dist
+++ b/conf/webwork.apache2.4-config.dist
@@ -153,7 +153,10 @@ if ($webwork_url eq "") {
 
 my $webwork3_htdocs_dir = $webwork_dir."/webwork3/public";
 # Set up /webwork3 to point to the dispatch cgi
-push @ScriptAlias, [ "/webwork3" => "$webwork3_htdocs_dir/dispatch.fcgi" ];
+push @Alias, [ "/webwork3/js" => "$webwork3_htdocs_dir/js"];
+push @Alias, [ "/webwork3/css" => "$webwork3_htdocs_dir/css"];
+push @Alias, [ "/webwork3/images" => "$webwork3_htdocs_dir/images"];
+push @PerlConfig, "ScriptAlias /webwork3 $webwork3_htdocs_dir/dispatch.fcgi";
 
 # Allow cgi to run in the webwork3 dir
 Directory{"$webwork3_htdocs_dir"} = {

--- a/conf/webwork3.conf.dist
+++ b/conf/webwork3.conf.dist
@@ -1,5 +1,6 @@
-# configuration file for development environment
-
+# configuration file for WeBWorK 3.  This is a YAML formatted file, not Perl
+# formatted like the other configuration files.  The webwork_dir, pg_dir, 
+# and database information needs to be set for WeBWorK 3 to work.  
 #
 #  The webwork directory needs to be set
 
@@ -9,7 +10,11 @@ pg_dir: "/opt/webwork/pg"
 # the logger engine to use
 # console: log messages to STDOUT (your console where you started the
 #          application server)
-# file:    log message to a file in log/
+# file:    log message to a file in logs/
+# Note: If you are running through apache and not a stand alone server you 
+# wont be able to see the log information.  To see the log information you 
+# need to change this to file and then make sure that webwork2/webwork3/logs
+# is owned, readable and writable by the wwdata group.  
 logger: "console"
 
 # the log level for this environment

--- a/webwork3/bin/app.pl
+++ b/webwork3/bin/app.pl
@@ -1,8 +1,13 @@
 #!/usr/bin/env perl
 use Dancer;
 use Dancer::Plugin::Database;
-use WeBWorK::DB;
+
+# link to WeBWorK code libraries
+use lib config->{webwork_dir}.'/lib';
+use lib config->{pg_dir}.'/lib';
+
 use WeBWorK::CourseEnvironment;
+use WeBWorK::DB;
 use WeBWorK::Authen;
 
 ## note: Routes::Authenication must be passed first
@@ -13,10 +18,6 @@ use Routes::ProblemSets;
 use Routes::User;
 use Routes::Settings;
 use Routes::PastAnswers;
-
-
-
-
 
 set serializer => 'JSON';
 
@@ -77,7 +78,7 @@ post '/courses/:course_id/login' => sub {
 
 	} else {
 		return {logged_in=>0};
-	}
+	} 
 };
 
 
@@ -97,7 +98,6 @@ get '/app-info' => sub {
 		session_name=>config->{session_name},
 		session_secure=>config->{session_secure},
 		session_is_http_only=>config->{session_is_http_only},
-		
 	};
 };
 

--- a/webwork3/environments/development.yml
+++ b/webwork3/environments/development.yml
@@ -1,0 +1,1 @@
+../../conf/webwork3.conf

--- a/webwork3/environments/development.yml.dist
+++ b/webwork3/environments/development.yml.dist
@@ -4,6 +4,7 @@
 #  The webwork directory needs to be set
 
 webwork_dir: "/opt/webwork/webwork2"
+pg_dir: "/opt/webwork/pg"
 
 # the logger engine to use
 # console: log messages to STDOUT (your console where you started the

--- a/webwork3/public/dispatch.cgi
+++ b/webwork3/public/dispatch.cgi
@@ -7,7 +7,7 @@ use Plack::Runner;
 # correctly to the dispatchers, so forcing PSGI and env here 
 # is safer.
 set apphandler => 'PSGI';
-set environment => 'production';
+set environment => 'development';
 
 my $psgi = path($RealBin, '..', 'bin', 'app.pl');
 die "Unable to read startup script: $psgi" unless -r $psgi;

--- a/webwork3/public/dispatch.fcgi
+++ b/webwork3/public/dispatch.fcgi
@@ -7,7 +7,7 @@ use Plack::Handler::FCGI;
 # correctly to the dispatchers, so forcing PSGI and env here 
 # is safer.
 set apphandler => 'PSGI';
-set environment => 'production';
+set environment => 'development';
 
 my $psgi = path($RealBin, '..', 'bin', 'app.pl');
 my $app = do($psgi);

--- a/webwork3/public/dispatch.fcgi
+++ b/webwork3/public/dispatch.fcgi
@@ -12,6 +12,6 @@ set environment => 'development';
 my $psgi = path($RealBin, '..', 'bin', 'app.pl');
 my $app = do($psgi);
 die "Unable to read startup script: $@" if $@;
-my $server = Plack::Handler::FCGI->new(nproc => 5, detach => 1);
+my $server = Plack::Handler::FCGI->new(nproc => 1, detach => 1);
 
 $server->run($app);


### PR DESCRIPTION
Changed things so that the dancer components of webwork3 are served via apache using cgi.

In order for this to work you need to enable the apache module fcgi (or fcgid) on your machine.  (I had to do 
sudo apt-get install libapache2-mod-fcgid).  You also need Plack::Runner (I did apt-get install libplack-perl).  

Note:  I'm still having trouble getting the manager to work, so there may be something incomplete here. 

Pros:  
- Dancer doesn't have to be started on its own.  This means that we don't have to worry about how to deploy dancer as a service on all the different distributions.  
- Dancer doesn't have to be run manually, in fact you can change something in dancer, hit refresh and it uses the new code. 

Cons: 
- It seems a little slower.  
- Its a little harder to get debug information since its not spewing onto the screen.  (Need to have a debug log file.)  
