### PR TITLE
Properly detect and use SQL::Abstract or SQL::Abstract::Classic

### DIFF
--- a/lib/WeBWorK/DB/Utils/SQLAbstractIdentTrans.pm
+++ b/lib/WeBWorK/DB/Utils/SQLAbstractIdentTrans.pm
@@ -15,13 +15,20 @@
 ################################################################################
 
 package WeBWorK::DB::Utils::SQLAbstractIdentTrans;
+my $BASE;
 BEGIN {
-	if ($SQL::Abstract::VERSION>1.87) {
-		use base qw(SQL::Abstract::Classic);
-	} else {
-		use base qw(SQL::Abstract);
-	}
+	my $sql_abstract = eval {
+		require SQL::Abstract;
+		if ($SQL::Abstract::VERSION > 1.87) {
+			0;
+		} else {
+			1;
+		};
+	};
+	$BASE = qw(SQL::Abstract) if $sql_abstract;
+	$BASE = qw(SQL::Abstract::Classic) unless $sql_abstract;
 }
+use base $BASE;
 
 =head1 NAME
 
@@ -93,7 +100,7 @@ sub _order_by {
     my @vals = $ref eq 'ARRAY'  ? @{$_[0]} :
                $ref eq 'SCALAR' ? $_[0]    : # modification: don't dereference scalar refs
                $ref eq ''       ? $_[0]    :
-               SQL::Abstract::Classic::puke "Unsupported data struct $ref for ORDER BY";
+			   $self->SUPER::puke("Unsupported data struct $ref for ORDER BY");
 
     # modification: if an item is a scalar ref, don't quote it, only dereference it
     my $val = join ', ', map { ref $_ eq "SCALAR" ? $$_ : $self->_quote($_) } @vals;


### PR DESCRIPTION
@pstaabp:  Your current code clearly doesn't work.  You are calling SQL::Abstract::Classic::puke in any case.  Furthermore, checking the variable $SQL::Abstract::VERSION won't work unless the module is loaded.  This fixes those things.  I have tested this in the following cases:
    SQL::Abstract installed via the Ubuntu package and SQL::Abstract::Classic not installed at all
    SQL::Abstract installed via the Ubuntu package and SQL::Abstract::Classic installed via cpanm
    SQL::Abstract not installed at all and SQL::Abstract::Classic installed via cpanm
    SQL::Actract install via cpanm and SQL::Abstract::Classic install via cpanm
All of these cases work.  Of course other cases will fail.