### PR TITLE
Patch for PR 1386

### DIFF
--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -2,12 +2,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
 # Copyright &copy; 2000-2021 The WeBWorK Project, http://github.com/openwebwork
-# 
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -25,7 +25,7 @@
 # This file is used to set up the basic paths and URLs specific to your
 # installation of WeBWorK, with the exception of the $webwork_dir variable which
 # is set in the WeBWorK Apache configuration file (webwork.apache2-config).
-# Any customization of global WeBWorK settings should be done in localOverrides.conf. 
+# Any customization of global WeBWorK settings should be done in localOverrides.conf.
 
 ################################################################################
 # site.conf  -- this file
@@ -51,8 +51,8 @@ $server_root_url   = '';   # e.g.  'https://webwork.yourschool.edu' or 'http://l
 # The following two variables must match the user ID and group ID respectively
 # under which apache is running.
 # In the apache configuration file (often called httpd.conf) you will find
-# User www-data or apache  --- this is the $server_userID 
-# Group www-data or apache   --- this is the $server_groupID 
+# User www-data or apache  --- this is the $server_userID
+# Group www-data or apache   --- this is the $server_groupID
 
 # uncomment (or change) the following depending on your OS
 
@@ -229,12 +229,12 @@ $database_storage_engine = 'myisam';
 #########################
 # MYSQL compatibility settings for handling international Unicode characters (utf8 and utf8mb)
 #########################
-# These set the way characters are encoded in mysql and will depend on the version of mysqld being used.  
-# the default is to use latin1.  With version 2.15 we will move to 
+# These set the way characters are encoded in mysql and will depend on the version of mysqld being used.
+# the default is to use latin1.  With version 2.15 we will move to
 # encoding utf8mb4 which allows the encoding of characters from many languages
 # including chinese, arabic and hebrew.
 
-$ENABLE_UTF8MB4 =1;    # setting this to 1 enables utf8mb4 encoding, setting this to 
+$ENABLE_UTF8MB4 =1;    # setting this to 1 enables utf8mb4 encoding, setting this to
 					   # 0 sets this for older mysql (pre 5.3) which cannot
 					   # handle utf8mb4 characters.
 
@@ -285,7 +285,7 @@ $mail{smtpSender} = '';  # e.g.  'webwork@yourserver.yourschool.edu'
 # Be sure to use single quotes for the address or the @ sign will be interpreted as an array.
 
 # Seconds to wait before timing out when connecting to the SMTP server.
-#  the default is 120 seconds.  
+#  the default is 120 seconds.
 # Change it by uncommenting the following line
 # set it to 5 for testing, 30 or larger for production
 
@@ -298,7 +298,7 @@ $mail{smtpTimeout}           = 30;
 # Set this value to 0 to avoid checking certificates.
 # Set it to 0 to trouble shoot an inability to verify certificates with the smtp server
 
-$mail{tls_allowed} = 0;  
+$mail{tls_allowed} = 0;
 
 #$tls_allowed=0;  #old method -- this variable no longer works.
 

--- a/docker-config/docker-entrypoint.sh
+++ b/docker-config/docker-entrypoint.sh
@@ -81,7 +81,8 @@ if [ "$1" = 'apache2' ]; then
                     -e 's/mail{smtpServer} = '\'''\''/mail{smtpServer} = $ENV{"WEBWORK_SMTP_SERVER"}/' \
                     -e 's/mail{smtpSender} = '\'''\''/mail{smtpSender} = $ENV{"WEBWORK_SMTP_SENDER"}/' \
                     -e 's/siteDefaults{timezone} = "America\/New_York"/siteDefaults{timezone} = $ENV{"WEBWORK_TIMEZONE"}/' \
-                    -e 's/$server_groupID    = '\''wwdata'\''/$server_groupID    = "www-data"/' \
+                    -e 's/^# $server_userID     = '\''www-data/$server_userID     = '\''www-data/'  \
+                    -e 's/^# $server_groupID    = '\''www-data/$server_groupID    = '\''www-data/' \
                     $WEBWORK_ROOT/conf/site.conf
             fi
         fi


### PR DESCRIPTION
Modify `docker-config/docker-entrypoint.sh` to set the correct `$server_userID` and `$server_groupID` for Ubuntu.

Clean up trailing whitespace in `conf/site.conf.dist`.