### PR TITLE
Patch # 2 for PR 1386 - fix bin/setfilepermissions

### DIFF
--- a/bin/setfilepermissions
+++ b/bin/setfilepermissions
@@ -50,6 +50,22 @@ chomp($me);
 #my $serverid =  $ce->{server_userID};
 my $servergroup =  $ce->{server_groupID};
 
+if ( ! $me ) {
+	# In a bash shell in a Docker container running webwork, the login name is usually not available.
+	if ( `/usr/bin/grep -c www-data /etc/passwd`) {
+		warn "No login name available, using www-data as the user name for the chown calls.";
+		$me = "www-data";
+	} elsif ( `/usr/bin/grep -c apache /etc/passwd`) {
+		warn "No login name available, using apache as the user name for the chown calls.";
+		$me = "apache";
+	} else {
+		die "Aborting: No login name available, and cannot fall back to www-data or apache for the chown calls.";
+	}
+}
+if ( ! $servergroup ) {
+	die "Aborting: server_groupID not set - so cannot do the chgrp calls. Check your conf/site.conf file.";
+}
+
 my $wwroot = $ENV{WEBWORK_ROOT};
 
 # Course directories


### PR DESCRIPTION
Modify `bin/setfilepermissions` to use fallback values for user (`www-data` or `apache`) when it can, and to die when it cannot.
Also die if it cannot determine the group to use from `$ce->{server_groupID}` (derived from `$server_groupID` in `conf/site.conf`).
Without the proper values - the `chown`/`chgrp` commands cannot be run.