### PR TITLE
Fixes and improvements for the new "Make Archive" page.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -185,7 +185,7 @@ RUN apt-get update \
 # ==================================================================
 # Phase 4 - Install additional Perl modules from CPAN that are not packaged for Ubuntu or are outdated in Ubuntu.
 
-RUN cpanm install Statistics::R::IO DBD::MariaDB Mojo::SQLite@3.002 Perl::Tidy@20220613 \
+RUN cpanm install Statistics::R::IO DBD::MariaDB Mojo::SQLite@3.002 Perl::Tidy@20220613 Archive::Zip::SimpleZip \
 	&& rm -fr ./cpanm /root/.cpanm /tmp/*
 
 # ==================================================================

--- a/DockerfileStage1
+++ b/DockerfileStage1
@@ -147,7 +147,7 @@ RUN apt-get update \
 # ==================================================================
 # Phase 3 - Install additional Perl modules from CPAN that are not packaged for Ubuntu or are outdated in Ubuntu.
 
-RUN cpanm install -n Statistics::R::IO DBD::MariaDB Mojo::SQLite@3.002 Perl::Tidy@20220613 \
+RUN cpanm install -n Statistics::R::IO DBD::MariaDB Mojo::SQLite@3.002 Perl::Tidy@20220613 Archive::Zip::SimpleZip \
 	&& rm -fr ./cpanm /root/.cpanm /tmp/*
 
 # ==================================================================

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -67,6 +67,7 @@ my @applicationsList = qw(
 my @modulesList = qw(
 	Archive::Extract
 	Archive::Zip
+	Archive::Zip::SimpleZip
 	Array::Utils
 	Benchmark
 	Carp

--- a/htdocs/js/FileManager/filemanager.js
+++ b/htdocs/js/FileManager/filemanager.js
@@ -43,19 +43,17 @@
 	};
 
 	// Used for the archive subpage to highlight all in the Select
-	const selectAllButton = document.getElementById('select-all-files-button');
-	selectAllButton?.addEventListener('click', () => {
-		const n = document.getElementById('archive-files').options.length;
-		for (const opt of document.getElementById('archive-files').options) {
-			opt.selected = 'selected';
+	document.getElementById('select-all-files-button')?.addEventListener('click', () => {
+		for (const option of document.getElementById('archive-files').options) {
+			option.selected = 'selected';
 		}
 	});
 
-
-	for (const r of document.querySelectorAll('input[name="archive_type"]')) {
-		r.addEventListener('click', () => {
-			const suffix = document.querySelector('input[name="archive_type"]:checked').value;
-			document.getElementById('filename_suffix').innerText = '.' + suffix;
+	for (const archiveTypeInput of document.querySelectorAll('input[name="archive_type"]')) {
+		archiveTypeInput.addEventListener('click', () => {
+			document.getElementById('filename_suffix').innerText = `.${
+				document.querySelector('input[name="archive_type"]:checked').value
+			}`;
 		});
 	}
 

--- a/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
@@ -44,7 +44,7 @@
 		% for my $file (@$files) {
 			% push(@files_to_compress, $file);
 			% my $path = path("$dir/$file");
-			% push(@files_to_compress, @{ $path->list_tree({ hidden => 1 })->map('to_rel', $dir) })
+			% push(@files_to_compress, @{ $path->list_tree({ dir => 1, hidden => 1 })->map('to_rel', $dir) })
 				% if (-d $path && !-l $path);
 		% }
 		%

--- a/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
@@ -1,12 +1,13 @@
-% # template for the archive subpage.
-<div class="card w-75 mx-auto">
+% use Mojo::File qw(path);
+%
+<div class="card mx-auto" style="max-width:700px">
 	<div class="card-body">
 		<div class="mb-3">
 			<b><%= maketext('The following files have been selected for archiving.  Select the type '
-				. 'of archive and any subset of the requested files.') =%> </b>
+				. 'of archive and any subset of the requested files.') =%></b>
 		</div>
 		<div class="row">
-		  <div class="col-4">
+			<div class="col-12">
 				<div class="input-group input-group-sm mb-2">
 					<span class="input-group-text"><%= maketext('Archive Filename') %>:</span>
 					<%= text_field archive_filename => '',
@@ -20,38 +21,38 @@
 			<div class="input-group input-group-sm mb-2">
 				<span class="input-group-text"><%= maketext('Archive Type') %>:</span>
 				<div class="input-group-text flex-grow-1">
-					<label class="form-check-label me-4">
+					<label class="form-check-label me-2">
 						<%= radio_button archive_type => 'zip', checked => undef, class => 'form-check-input mx-1' =%>
 						<%= maketext('Zip File') =%>
 					</label>
-					<label class="form-check-label me-4">
+					<label class="form-check-label">
 						<%= radio_button archive_type => 'tgz', class => 'form-check-input mx-1' =%>
 						<%= maketext('Compressed Tar') =%>
 					</label>
-					<button type="button" class="btn btn-sm btn-secondary" id="select-all-files-button">
-						<%= maketext('Select All Files') =%>
-					</button>
 				</div>
 			</div>
 		</div>
-
-
+		<div class="row mb-2">
+			<div class="col-12">
+				<button type="button" class="btn btn-sm btn-secondary" id="select-all-files-button">
+					<%= maketext('Select All Files') =%>
+				</button>
+			</div>
+		</div>
+		%
 		% my @files_to_compress;
-		% chdir($dir);
-		% for my $f (@$files) {
-		% 	push(@files_to_compress, glob("$f/**")) if -d $f;
-		% 	push(@files_to_compress, $f)            if -f $f;
+		% for my $file (@$files) {
+			% push(@files_to_compress, $file);
+			% my $path = path("$dir/$file");
+			% push(@files_to_compress, @{ $path->list_tree({ hidden => 1 })->map('to_rel', $dir) })
+				% if (-d $path && !-l $path);
 		% }
-		% # remove any directories
-		% @files_to_compress = grep { -f $_ } @files_to_compress;
-
-		<%= select_field files => \@files_to_compress,
-					id    => 'archive-files',
-					class => 'form-select',
-					size => 20,
-					multiple => undef
-				=%>
-
+		%
+		% # Select all files initially. Even those that are in previously selected directories or subdirectories.
+		% param('files', \@files_to_compress);
+		<%= select_field files => \@files_to_compress, id => 'archive-files', class => 'form-select mb-2',
+			size => 20, multiple => undef =%>
+		%
 		<p><%= maketext('Create the archive of the select files?') %></p>
 		<div class="d-flex justify-content-evenly">
 			<%= submit_button maketext('Cancel'), name => 'action', class => 'btn btn-sm btn-secondary' =%>
@@ -59,4 +60,5 @@
 		</div>
 	</div>
 </div>
+<%= hidden_field confirmed => 'MakeArchive' =%>
 <%= $c->HiddenFlags =%>

--- a/templates/ContentGenerator/Instructor/FileManager/refresh.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/refresh.html.ep
@@ -34,7 +34,7 @@
 			dir => 'ltr', size => 17, multiple => undef =%>
 	</div>
 	<div class="col-md-4 mb-2">
-		<div class="d-md-flex flex-column justify-content-evenly">
+		<div class="d-flex flex-md-column flex-wrap flex-md-nowrap justify-content-evenly gap-1 gap-md-0">
 			<%= submit_button maketext('View'), id => 'View', %button =%>
 			<%= submit_button maketext('Edit'), id => 'Edit', %button =%>
 			<%= submit_button maketext('Download'), id => 'Download', %button =%>
@@ -50,7 +50,7 @@
 			% unless ($c->{courseName} eq 'admin') {
 				<%= submit_button maketext('Archive Course'), id => 'ArchiveCourse', %button =%>
 			% }
-			<div style="height: 10px"></div>
+			<div class="d-none d-md-block" style="height: 10px"></div>
 			<%= submit_button maketext('New File'), id => 'NewFile', %button =%>
 			<%= submit_button maketext('New Folder'), id => 'NewFolder', %button =%>
 			<%= submit_button maketext('Refresh'), id => 'Refresh', %button =%>


### PR DESCRIPTION
Fix the action.  There needs to be a hidden "confirm" input.

Improve layouts.

Also other clean up suggested in my review of #2163.

Don't use `chdir`.

The IO::Compression::Zip module is too limited.  It can not add directories to the zip file.  Empty directories in particular should be. So use Archive::Zip instead.  This module is already in use by webwork as well.

This skips adding symbolic links to zip archives for now.  I am working on that though.