### PR TITLE
Change the way that the archive type is determined.

### DIFF
--- a/htdocs/js/FileManager/filemanager.js
+++ b/htdocs/js/FileManager/filemanager.js
@@ -45,6 +45,19 @@
 	files?.addEventListener('change', checkFiles);
 	if (files) checkFiles();
 
+	const archiveFilenameInput = document.getElementById('archive-filename');
+	const archiveTypeSelect = document.getElementById('archive-type');
+	if (archiveFilenameInput && archiveTypeSelect) {
+		archiveTypeSelect.addEventListener('change', () => {
+			if (archiveTypeSelect.value) {
+				archiveFilenameInput.value = archiveFilenameInput.value.replace(
+					/\.(zip|tgz|tar.gz)$/,
+					`.${archiveTypeSelect.value}`
+				);
+			}
+		});
+	}
+
 	const file = document.getElementById('file');
 	const uploadButton = document.getElementById('Upload');
 	const checkFile = () => (uploadButton.disabled = file.value === '');

--- a/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
@@ -10,20 +10,26 @@
 			<div class="col-12">
 				<div class="input-group input-group-sm mb-2">
 					<label class="input-group-text" for="archive-filename"><%= maketext('Archive Filename') %>:</label>
-					<%= text_field archive_filename => @$files == 1 ? $files->[0] =~ s/\..*$//r : 'webwork_files',
+					<%= text_field archive_filename =>
+							@$files == 1 ? $files->[0] =~ s/\..*$/.zip/r : 'webwork_files.zip',
 						id => 'archive-filename', placeholder => maketext('Archive Filename'),
-						class => 'form-control text-end', size => 30 =%>
-					<%= select_field archive_type => [
-							[ maketext('Archive Type') => '', disabled => undef, id => 'archive-type-label' ],
-							[ '.zip' => 'zip', selected => undef ],
-							[ '.tgz' => 'tgz' ]
-						],
-						class => 'form-select', style => 'max-width: 7em', 'aria-labelledby' => 'archive-type-label' =%>
+						class => 'form-control', size => 30, dir => 'ltr' =%>
 				</div>
 			</div>
 		</div>
 		<div class="row">
-			<div class="col-md-12">
+			<div class="col-12 col-lg-6">
+				<div class="input-group input-group-sm mb-2">
+					<label class="input-group-text" for="archive-type"><%= maketext('Archive Type') %>:</label>
+					<%= select_field archive_type => [
+							[ maketext('By extension') => '', selected => undef ],
+							[ 'zip'                    => 'zip' ],
+							[ 'tar'                    => 'tgz' ]
+						],
+						class => 'form-select', id => 'archive-type' =%>
+				</div>
+			</div>
+			<div class="col-12 col-lg-6">
 				<div class="input-group input-group-sm mb-2">
 					<div class="input-group-text flex-grow-1">
 						<label class="form-check-label">
@@ -46,9 +52,8 @@
 		% # Select all files initially. Even those that are in previously selected directories or subdirectories.
 		% param('files', \@files_to_compress) unless param('confirmed');
 		<%= select_field files => \@files_to_compress, id => 'archive-files', class => 'form-select mb-2',
-			'arialabelled-by' => 'files-label', size => 20, multiple => undef =%>
+			'arialabelled-by' => 'files-label', size => 20, multiple => undef, dir => 'ltr' =%>
 		%
-		<p><%= maketext('Create archive of the selected files?') %></p>
 		<div class="d-flex justify-content-evenly">
 			<%= submit_button maketext('Cancel'), name => 'action', class => 'btn btn-sm btn-secondary' =%>
 			<%= submit_button maketext('Make Archive'), name => 'action', class => 'btn btn-sm btn-primary' =%>


### PR DESCRIPTION
This adds a "By extension" option to the archive type dropdown which is the default option.  If that option is selected, then the archive type will be determined by the extension given in the file name.  If the file name does not have a valid archive extension, then the zip archive type is assumed and that extension is added.  If zip or tar is selected then the zip or tgz extension is added to the filename (if it doesn't already have that extension), and of course that archive type is used. Note that describes the server side behavior.  Javascript also changes the extension in the input client side.

Note that the `.tar.gz` extension is also supported if explicitly given for the filename extension.

Note that at or above the large breakpoint the archive type dropdown and "Overwrite existing archive" checkbox will be on the second line together.  Below the large breakpoint, they will be on separate lines.

Also `dir="ltr"` is added to both the archive filename input and the files select.

Also remove the "Create archive of the selected files?" question.  The presented answers are not valid for that question, and the question isn't needed with the instructions at the top, as well as the fact that the buttons are clear as to what they will do.