### PR TITLE
Validate the archive filename.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
@@ -362,12 +362,7 @@ sub MakeArchive ($c) {
 		return $c->Refresh if $action eq 'Cancel' || $action eq $c->maketext('Cancel');
 
 		unless ($c->param('archive_filename')) {
-			$c->addbadmessage($c->maketext('The filename cannot be empty.'));
-			return $c->include('ContentGenerator/Instructor/FileManager/archive', dir => $dir, files => \@files);
-		}
-
-		unless (@files > 0) {
-			$c->addbadmessage($c->maketext('At least one file must be selected'));
+			$c->addbadmessage($c->maketext('The archive filename cannot be empty.'));
 			return $c->include('ContentGenerator/Instructor/FileManager/archive', dir => $dir, files => \@files);
 		}
 
@@ -384,11 +379,26 @@ sub MakeArchive ($c) {
 			$archive =~ s/(\.zip)?$/.tgz/ unless $archive =~ /\.(tgz|tar.gz)$/;
 		}
 
+		# Check filename validity.
+		if ($archive =~ m!/!) {
+			$c->addbadmessage($c->maketext('The archive filename may not contain a path component'));
+			return $c->include('ContentGenerator/Instructor/FileManager/archive', dir => $dir, files => \@files);
+		}
+		if ($archive =~ m!^\.! || $archive =~ m![^-_.a-zA-Z0-9 ]!) {
+			$c->addbadmessage($c->maketext('The archive filename contains illegal characters'));
+			return $c->include('ContentGenerator/Instructor/FileManager/archive', dir => $dir, files => \@files);
+		}
+
 		if (-e "$dir/$archive" && !$c->param('overwrite')) {
 			$c->addbadmessage($c->maketext(
 				'The file [_1] exists. Check "Overwrite existing archive" to force this file to be replaced.',
 				$archive
 			));
+			return $c->include('ContentGenerator/Instructor/FileManager/archive', dir => $dir, files => \@files);
+		}
+
+		unless (@files > 0) {
+			$c->addbadmessage($c->maketext('At least one file must be selected'));
 			return $c->include('ContentGenerator/Instructor/FileManager/archive', dir => $dir, files => \@files);
 		}
 

--- a/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
@@ -52,7 +52,7 @@
 		% # Select all files initially. Even those that are in previously selected directories or subdirectories.
 		% param('files', \@files_to_compress) unless param('confirmed');
 		<%= select_field files => \@files_to_compress, id => 'archive-files', class => 'form-select mb-2',
-			'arialabelled-by' => 'files-label', size => 20, multiple => undef, dir => 'ltr' =%>
+			'aria-labelledby' => 'files-label', size => 20, multiple => undef, dir => 'ltr' =%>
 		%
 		<div class="d-flex justify-content-evenly">
 			<%= submit_button maketext('Cancel'), name => 'action', class => 'btn btn-sm btn-secondary' =%>


### PR DESCRIPTION
This ensures that the filename does not contain a path component, and that it only contains valid characters for a filename in general.