### PR TITLE
Switch to using `Archive::Zip` and `Archive::Tar` to extract archives.

### DIFF
--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -65,7 +65,6 @@ my @applicationsList = qw(
 );
 
 my @modulesList = qw(
-	Archive::Extract
 	Archive::Zip
 	Archive::Zip::SimpleZip
 	Array::Utils

--- a/templates/HelpFiles/InstructorFileManager.html.ep
+++ b/templates/HelpFiles/InstructorFileManager.html.ep
@@ -18,8 +18,8 @@
 %
 <p>
 	<%= maketext('This allows for the viewing, downloading, uploading and other management '
-		. 'of files in the course.  Select a file or set of files (using CTRL or SHIFT) and click '
-		. 'the desired button on the right.  Many actions can only be done with a single file (like '
+		. 'of files in the course. Select a file or set of files (using CTRL or SHIFT) and click '
+		. 'the desired button on the right. Many actions can only be done with a single file (like '
 		. 'view). Selecting a directory or set of files and clicking "Make Archive" allows the creation '
 		. 'of a compressed tar or zip file.') =%>
 </p>
@@ -29,14 +29,13 @@
 </p>
 <p>
 	<%= maketext('Below the file list is a button and options for uploading files. Click the "Choose File" '
-		. 'button, select the file, then click "Upload". '
-		. 'A single file or a compressed tar (.tgz) file can be uploaded and if the option is selected, '
-		. 'the archive is automatically unpacked and deleted.  Generally the "automatic" option on Format '
-		. 'will correctly pick the correct type of file.') =%>
+		. 'button, select the file, then click "Upload". Generally the "automatic" option on Format will '
+		. 'correctly pick the correct type of file. A single file or a compressed tar (.tgz) file can be '
+		. 'uploaded and if the options are selected, the archive is automatically unpacked and deleted.') =%>
 </p>
 <p>
-	<%= maketext('WeBWorK expects many files to be in certain locations.  The following describe this. '
-	. 'Note that by default the File Manager shows the "templates" directory.  Other directories mentioned '
+	<%= maketext('WeBWorK expects many files to be in certain locations. The following describe this. '
+	. 'Note that by default the File Manager shows the "templates" directory. Other directories mentioned '
 	. 'below are at the same level and need to be accessed by going up a directory by clicking the "^" button '
 	. 'above the file list.') =%>
 </p>
@@ -48,7 +47,7 @@
 			. '<strong>Set Definition files</strong> is described in the <a [_1]>Set Definition specification</a>. '
 			. 'Set definition files are mainly useful for '
 			. 'transferring set assignments from one course to another and are created when exporting a problem '
-			. 'set from the "Hmwk Sets Editor".  Each set defintion file contains a list of problems used and the '
+			. 'set from the "Hmwk Sets Editor". Each set defintion file contains a list of problems used and the '
 			. 'dates and times. These definitions can be imported into the current course.',
 			'href="https://webwork.maa.org/wiki/Set_Definition_Files" target="Webworkdocs"') =%>
 	</dd>
@@ -58,10 +57,10 @@
 			. 'a large number of students into your class. To view the format for <strong>ClassList files</strong> see '
 			. 'the <a [_1]>ClassList specification</a> or download the [_2] file and use it as a model. '
 			. 'ClassList files can be prepared using a spreadsheet and then saved as [_3] (comma separated values) '
-			. 'text files.  However, to access as a classlist file, the file suffix needs to be changed to [_4], '
+			. 'text files. However, to access as a classlist file, the file suffix needs to be changed to [_4], '
 			. 'which can be done with the "Rename" button.',
 			'href="http://webwork.maa.org/wiki/Classlist_Files#Format_of_classlist_files" target="Webworkdocs"',
-			'<code>demoCourse.lst</code>','<code>.csv</code>','<code>.lst</code>') =%>
+			'<code>demoCourse.lst</code>', '<code>.csv</code>', '<code>.lst</code>') =%>
 	</dd>
 	<dt><%= maketext('Scoring (".csv") files') %></dt>
 	<dd>


### PR DESCRIPTION
The `Archive::Extract` module is not safe with zip files and can extract files outside of the current working directory (assuming the server has write permission to do so).

The `Archive::Zip` and `Archive::Tar` modules will not extract outside of the current working directory (by default).

Additionally, using the `Archive::Zip` and `Archive::Tar` modules gives more power for archive extraction. If the "Overwrite existing files silenetly" checkbox is not checked, then this now checks each file in the archive to see if extracting it will overwrite an existing file.  If so it refuses to do so, and a message is displayed.