### PR TITLE
Fix messages for existing files or files outside the course directory.

### DIFF
--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -456,7 +456,7 @@ h2.page-title {
 	gap: 0.25rem;
 	margin: 0 0 0.5rem;
 
-	p {
+	div {
 		margin: 0;
 	}
 }

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -265,8 +265,9 @@ message() template escape handler.
 
 sub addgoodmessage ($c, $message) {
 	$c->addmessage($c->tag(
-		'p',
+		'div',
 		class => 'alert alert-success alert-dismissible fade show ps-1 py-1',
+		role  => 'alert',
 		$c->c(
 			$message,
 			$c->tag(
@@ -290,8 +291,9 @@ message() template escape handler.
 
 sub addbadmessage ($c, $message) {
 	$c->addmessage($c->tag(
-		'p',
+		'div',
 		class => 'alert alert-danger alert-dismissible fade show ps-1 py-1',
+		role  => 'alert',
 		$c->c(
 			$message,
 			$c->tag(

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -81,6 +81,7 @@ our @EXPORT_OK = qw(
 	list2hash
 	listFilesRecursive
 	makeTempDirectory
+	min
 	max
 	nfreeze_base64
 	not_blank
@@ -1049,15 +1050,22 @@ sub thaw_base64 {
 
 }
 
-sub max(@) {
-	my $soFar;
-	foreach my $item (@_) {
-		$soFar = $item unless defined $soFar;
-		if ($item > $soFar) {
-			$soFar = $item;
-		}
+sub min {
+	my @items = @_;
+	my $min   = (shift @items) // 0;
+	for my $item (@items) {
+		$min = $item if ($item < $min);
 	}
-	return defined $soFar ? $soFar : 0;
+	return $min;
+}
+
+sub max {
+	my @items = @_;
+	my $max   = (shift @items) // 0;
+	for my $item (@items) {
+		$max = $item if ($item > $max);
+	}
+	return $max;
 }
 
 sub wwRound(@) {


### PR DESCRIPTION
This makes it so that the first thirty files in both lists are shown. If there are more than thirty, then the last item in the list will say that there are more files not shown.

To make this work a `min` method was added to Utils.pm (there was a max method, but no min method?), and the change in #2194 to make good and bad messages be in a `div` instead of a `p` was added here too.