### PR TITLE
Improvements to showing the deprecated macros warning.

### DIFF
--- a/htdocs/js/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/PGProblemEditor/pgproblemeditor.js
@@ -514,13 +514,13 @@
 					}
 					if (data.deprecated_macros?.length) {
 						const container = document.createElement('div');
-						container.classList.add('alert', 'alert-danger', 'mx-2');
+						container.classList.add('alert', 'alert-danger', 'mx-2', 'p-2');
 						container.innerHTML =
-							'<p>Warning!! This problem uses the following deprecated macros:</p>' +
-							'<ul class="mb-0">' +
+							'Warning!! This problem uses the following deprecated macros:' +
+							'<ul class="my-1">' +
 							data.deprecated_macros.reduce((acc, item) => `${acc}<li>${item}</li>`, '') +
-							'</ul><p>If this is an OPL problem, please report this issue to the OPL. ' +
-							'If this is a custom problem, please update the problem to use modern macros.</p>';
+							'</ul>If this is an OPL problem, please report this issue to the OPL. ' +
+							'If this is a custom problem, please update the problem to use modern macros.';
 						iframe.after(container);
 					}
 

--- a/htdocs/js/RenderProblem/renderproblem.js
+++ b/htdocs/js/RenderProblem/renderproblem.js
@@ -79,13 +79,13 @@
 						}
 						if (data.deprecated_macros?.length) {
 							const container = document.createElement('div');
-							container.classList.add('alert', 'alert-danger');
+							container.classList.add('alert', 'alert-danger', 'p-2');
 							container.innerHTML =
-								'<p>Warning!! This problem uses the following deprecated macros:</p>' +
-								'<ul class="mb-0">' +
+								'Warning!! This problem uses the following deprecated macros:' +
+								'<ul class="my-1">' +
 								data.deprecated_macros.reduce((acc, item) => `${acc}<li>${item}</li>`, '') +
-								'</ul><p>If this is an OPL problem, please report this issue to the OPL. ' +
-								'If this is a custom problem, please update the problem to use modern macros.</p>';
+								'</ul>If this is an OPL problem, please report this issue to the OPL. ' +
+								'If this is a custom problem, please update the problem to use modern macros.';
 							iframe.after(container);
 						}
 						iFrameResize(

--- a/lib/WeBWorK/Utils/Rendering.pm
+++ b/lib/WeBWorK/Utils/Rendering.pm
@@ -253,19 +253,12 @@ sub renderPG ($c, $effectiveUser, $set, $problem, $psvn, $formFields, $translati
 			flags            => $pg->{flags},
 		};
 
-		# get a list of the deprecated macros
-		my @deprecated_macros;
-		for (keys %{ $pg->{pgcore}{PG_loadMacros}{macroFileList} }) {
-			my @dirs = split('/', $_);
-			push(@deprecated_macros, $dirs[-1]) if $dirs[-2] eq 'deprecated';
-		}
-
 		if (ref($pg->{pgcore}) eq 'PGcore') {
 			$ret->{internal_debug_messages} = $pg->{pgcore}->get_internal_debug_messages;
 			$ret->{warning_messages}        = $pg->{pgcore}->get_warning_messages();
 			$ret->{debug_messages}          = $pg->{pgcore}->get_debug_messages();
-			$ret->{deprecated_macros}       = \@deprecated_macros;
-			$ret->{PG_ANSWERS_HASH}         = {
+
+			$ret->{PG_ANSWERS_HASH} = {
 				map {
 					$_ => {
 						response_obj => unbless($pg->{pgcore}{PG_ANSWERS_HASH}{$_}->response_obj),
@@ -279,6 +272,14 @@ sub renderPG ($c, $effectiveUser, $set, $problem, $psvn, $formFields, $translati
 					keys %{ $pg->{pgcore}{PG_alias}{resource_list} }
 			};
 			$ret->{PERSISTENCE_HASH} = $pg->{pgcore}{PERSISTENCE_HASH};
+
+			# Get a list of the deprecated macros used in the problem.
+			my @deprecated_macros;
+			for (keys %{ $pg->{pgcore}{PG_loadMacros}{macroFileList} }) {
+				my @dirs = split('/', $_);
+				push(@deprecated_macros, $dirs[-1]) if $dirs[-2] eq 'deprecated';
+			}
+			$ret->{deprecated_macros} = \@deprecated_macros;
 		}
 
 		# Save the problem source. This is used by Caliper::Entity. Why?


### PR DESCRIPTION
Only parse the macro file list if the PGcore object is in the result.

Also, remove the `p` tags and tweak the style of the html generated to display the deprecated macros list to get consistent spacing.